### PR TITLE
Respect the `platform` in platform_augmentation.jl

### DIFF
--- a/.pkg/platform_augmentation.jl
+++ b/.pkg/platform_augmentation.jl
@@ -7,7 +7,7 @@ const preferences = Base.get_preferences(MPIPreferences_UUID)
 function augment_mpi!(platform)
     # Doesn't need to be `const` since we depend on MPIPreferences so we
     # invalidate the cache when it changes.
-    binary = get(preferences, "binary", Sys.iswindows() ? "MicrosoftMPI_jll" : "MPICH_jll")
+    binary = get(preferences, "binary", platform["os"] == "windows" ? "MicrosoftMPI_jll" : "MPICH_jll")
 
     abi = if binary == "system"
         let abi = get(preferences, "abi", nothing)


### PR DESCRIPTION
This PR makes the script in `platform_augmentation.jl` respect the `platform` argument.

I'm not entirely following why, but running 

```Julia
Pkg.instantiate(platform = Pkg.BinaryPlatforms.Windows(:x86_64))
```

in a project with HDF5 added *from my Mac* does not install any HDF5 artifact unless I make this change.  This bug was discovered in development of https://github.com/JuliaComputing/DepotDelivery.jl